### PR TITLE
Add chain task apply_async priority

### DIFF
--- a/t/unit/tasks/test_canvas.py
+++ b/t/unit/tasks/test_canvas.py
@@ -602,6 +602,10 @@ class test_chain(CanvasCase):
         c.apply_async(link_error=[s('error')])
         for task in c.tasks:
             assert task.options['link_error'] == [s('error')]
+        
+        c.apply_async(priority=5)
+        for task in c.tasks:
+            assert task.options['priority'] == 5
 
     def test_apply_options_none(self):
         class static(Signature):


### PR DESCRIPTION
Refer https://github.com/celery/celery/pull/5759#issuecomment-1270413045 for how this fails.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/master/contributing.html).

## Description

When chaining tasks with .s and .si and adding priority while calling .apply_async on the chain, it should ideally propagate to all tasks of the chain.

Added test checks that all tasks of the chain have same priority as the one provided in apply_async

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
